### PR TITLE
Calculate rotation correctly when pointers change order

### DIFF
--- a/src/inputjs/get-rotation.js
+++ b/src/inputjs/get-rotation.js
@@ -9,5 +9,11 @@ import { PROPS_CLIENT_XY } from './input-consts';
  * @return {Number} rotation
  */
 export default function getRotation(start, end) {
-  return getAngle(end[1], end[0], PROPS_CLIENT_XY) + getAngle(start[1], start[0], PROPS_CLIENT_XY);
+  let startSorted = start[0].identifier < start[1].identifier;
+  let start0 = startSorted ? start[0] : start[1];
+  let start1 = startSorted ? start[1] : start[0];
+  let endSorted = end[0].identifier < end[1].identifier;
+  let end0 = endSorted ? end[0] : end[1];
+  let end1 = endSorted ? end[1] : end[0];
+  return getAngle(end0, end1, PROPS_CLIENT_XY) - getAngle(start0, start1, PROPS_CLIENT_XY);
 }


### PR DESCRIPTION
Fix #791 by always calculating rotation by considering pointers in order of their identifier. This catches edge cases where pointers change order in the array during a gesture.